### PR TITLE
Add weekly dependabot job

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+- package-ecosystem: cargo
+  directory: "/"
+  schedule:
+    interval: weekly
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly


### PR DESCRIPTION
For keeping the dependencies of this crate up to date, we could use a dependabot job.